### PR TITLE
Required input class added with examples

### DIFF
--- a/jade/question.jade
+++ b/jade/question.jade
@@ -1,4 +1,4 @@
-.form-group(ng-class="tag.required == '1' ? 'inputRequired' : ''")
+.form-group(ng-class="{'input-required':tag.required}")
   label.control-label.col-sm-2(for="{{tag.id}}") {{tag.description}}
   .col-sm-10(ng-switch="tag.tagtype")
     input.form-control(ng-switch-when="T", type="text", id="{{tag.id}}", name="{{tag.id}}", ng-disabled='!isEditing', ng-model='tag.value', ng-required='tag.required')

--- a/jade/question.jade
+++ b/jade/question.jade
@@ -1,4 +1,4 @@
-.form-group
+.form-group(ng-class="tag.required == '1' ? 'inputRequired' : ''")
   label.control-label.col-sm-2(for="{{tag.id}}") {{tag.description}}
   .col-sm-10(ng-switch="tag.tagtype")
     input.form-control(ng-switch-when="T", type="text", id="{{tag.id}}", name="{{tag.id}}", ng-disabled='!isEditing', ng-model='tag.value', ng-required='tag.required')

--- a/stylus/app.styl
+++ b/stylus/app.styl
@@ -89,7 +89,7 @@ form > footer.navbar-default
   .dropdown-menu
     z-index:999999 !important
     
-.inputRequired > label::after
+.input-required > label::after
   content: " * "
   color:red
   font-size:12pt

--- a/stylus/app.styl
+++ b/stylus/app.styl
@@ -88,3 +88,8 @@ form > footer.navbar-default
   
   .dropdown-menu
     z-index:999999 !important
+    
+.inputRequired > label::after
+  content: " * "
+  color:red
+  font-size:12pt


### PR DESCRIPTION
- Added class to the required form group
- Pseudo selector used in style sheet to add asterisk to end of label

Example of adding asterisk:
```STYLUS
  .inputRequired > label::after
    content: " * "
    color:red
    font-size:12pt
```

Example of selecting required input
```STYLUS
  .inputRequired .col-sm-10 .form-control
    border: 5px solid red
```